### PR TITLE
Update lecture3.ipynb

### DIFF
--- a/lecture3.ipynb
+++ b/lecture3.ipynb
@@ -268,7 +268,7 @@
     "    concat_feat = np.concatenate(([lbp_energy,lbp_entropy],feat_glcm,[gabor_energy,gabor_entropy]),axis=0)    \n",
     "    testFeats[ts,:] = concat_feat  #Stacking features vectors for each image\n",
     "    # Class label\n",
-    "    label.append(trainDset[tr][1])\n",
+    "    label.append(testDset[ts][1])\n",
     "testLabel = np.array(label)"
    ]
   },


### PR DESCRIPTION
There is a misprint in the test-labeling in the lecture 3, caused by copypasting from the train-labeling block